### PR TITLE
修复fillBuffer可能存在重复消费的问题

### DIFF
--- a/core/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/core/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -121,14 +121,18 @@ class AnalyzeContext {
     		readCount = reader.read(segmentBuff);
 			this.lastUselessCharNum = 0;
     	}else{
-    		int offset = this.available - this.cursor;
-    		if(offset > 0){
-    			//最近一次读取的>最近一次处理的，将未处理的字串拷贝到segmentBuff头部
-    			System.arraycopy(this.segmentBuff , this.cursor , this.segmentBuff , 0 , offset);
-    			readCount = offset;
-    		}
-    		//继续读取reader ，以onceReadIn - onceAnalyzed为起始位置，继续填充segmentBuff剩余的部分
-    		readCount += reader.read(this.segmentBuff , offset , BUFF_SIZE - offset);
+			// cursor + 1 防止最后一个字符拷贝到segmentBuff头部，导致重复消费的问题。
+			int offset = this.available - (this.cursor + 1);
+			if(offset > 0){
+				//最近一次读取的>最近一次处理的，将未处理的字串拷贝到segmentBuff头部
+				System.arraycopy(this.segmentBuff , this.cursor , this.segmentBuff , 0 , offset);
+				readCount = offset;
+			}
+			//继续读取reader ，以onceReadIn - onceAnalyzed为起始位置，继续填充segmentBuff剩余的部分
+			int leftCount = reader.read(this.segmentBuff, offset, BUFF_SIZE - offset);
+			if (leftCount > 0) {
+				readCount += leftCount;
+			}
     	}            	
     	//记录最后一次从Reader中读入的可用字符长度
     	this.available = readCount;


### PR DESCRIPTION
fillBuffer在计算offset时，使用available - cursor，cursor的取值范围为[0，available)，所以offset最小值为1，不可能为0，导致会将segmentBuff[cursor]的值移动到segmentBuff[0]的位置，如果reader中还有未处理的数据，会导致segmentBuff[cursor]被第二次分词。
例子："hello, 我是一个测试。123"
![before](https://github.com/user-attachments/assets/60dd8b3b-e92f-4499-bd16-5a76eacf4e06)
available=17，分词处理后cursor=16，offset = 1。
![process](https://github.com/user-attachments/assets/3eac368f-65d4-4a46-afe9-a5fb725ac6f0)
已经处理过的字符'3'被移动到头部，把'h'覆盖掉了，同时reader.read()返回-1，readcount最后等于0（-1+1）。
![after](https://github.com/user-attachments/assets/4ac57708-63e8-463e-94ff-3db128f9d7ce)
如果reader中还有未处理的数据，则'3'会被重复分词。
